### PR TITLE
清理net45下的依赖包

### DIFF
--- a/src/ICanPay.Core/ICanPay.Core.csproj
+++ b/src/ICanPay.Core/ICanPay.Core.csproj
@@ -27,15 +27,16 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.Web" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.1" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
net45可以直接引用框架中的包, 而不是netstandard1.x的包
netstandard2.0匹配的最低版本的包应该是4.4.0而不是4.1.0